### PR TITLE
 Allow tweaking k3d fixes from the provider configuration 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.4
 
 require (
 	github.com/docker/go-connections v0.5.0
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-docs v0.14.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/k3d-io/k3d/v5 v5.8.1
@@ -60,7 +61,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320 // indirect
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.5.1 // indirect

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,9 +2,13 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/k3d-io/k3d/v5/pkg/runtimes"
+	"github.com/k3d-io/k3d/v5/pkg/types/fixes"
 )
 
 func init() {
@@ -26,6 +30,30 @@ func init() {
 func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
 		p := &schema.Provider{
+			Schema: map[string]*schema.Schema{
+				"fixes": {
+					// https://pkg.go.dev/github.com/k3d-io/k3d/v5/pkg/types/fixes#pkg-variables
+					Description: "Explicitly enable or disable K3d fixes during cluster creation.",
+					Type:        schema.TypeMap,
+					ForceNew:    true,
+					Optional:    true,
+					Elem:        &schema.Schema{Type: schema.TypeBool},
+					ValidateDiagFunc: func(m interface{}, path cty.Path) diag.Diagnostics {
+						var diags diag.Diagnostics
+						for key := range m.(map[string]interface{}) {
+							if _, ok := supportedFixes[key]; !ok {
+								diags = append(diags, diag.Diagnostic{
+									Severity:      diag.Error,
+									Summary:       "Invalid map key",
+									Detail:        fmt.Sprintf("Unsupported fix: %s", key),
+									AttributePath: append(path, cty.IndexStep{Key: cty.StringVal(key)}),
+								})
+							}
+						}
+						return diags
+					},
+				},
+			},
 			DataSourcesMap: map[string]*schema.Resource{
 				"k3d_cluster":  dataSourceCluster(),
 				"k3d_node":     dataSourceNode(),
@@ -51,11 +79,35 @@ type apiClient struct {
 }
 
 func configure(version string, p *schema.Provider) func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
-	return func(context.Context, *schema.ResourceData) (interface{}, diag.Diagnostics) {
+	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		// Setup a User-Agent for your API client (replace the provider name for yours):
 		// userAgent := p.UserAgent("terraform-provider-k3d", version)
 		// TODO: myClient.UserAgent = userAgent
 
+		if l, ok := d.GetOk("fixes"); ok {
+			configureFixes(l.(map[string]interface{}))
+		}
+
 		return &apiClient{}, nil
+	}
+}
+
+// Synced with https://pkg.go.dev/github.com/k3d-io/k3d/v5/pkg/types/fixes#K3DFixEnv
+// as of 5.8.1
+var supportedFixes = map[string]fixes.K3DFixEnv{
+	"cgroupv2": fixes.EnvFixCgroupV2,
+	"dns":      fixes.EnvFixDNS,
+	"mounts":   fixes.EnvFixMounts,
+}
+
+func configureFixes(fixesConfig map[string]interface{}) {
+	// Fixes configuration sadly uses a package-level variable, so it can only be configured at provider level and not per cluster
+	k3dFixes, _ := fixes.GetFixes(runtimes.SelectedRuntime)
+	for name, fix := range supportedFixes {
+		v, ok := fixesConfig[name]
+		if !ok {
+			continue
+		}
+		k3dFixes[fix] = v.(bool)
 	}
 }


### PR DESCRIPTION
K3d configures certain entrypoint scripts that run during the container start and perform certain additional configurations (see their descriptions [here](https://pkg.go.dev/github.com/k3d-io/k3d/v5/pkg/types/fixes#K3DFixEnv)).
However, they are not exposed via command line arguments during cluster creation, but instead must be set as environment variables when calling `k3d`.
Alternatively, as this provider uses k3d as a library, and it exposes a package-level variable, these values can be accessed and modified programmatically.

Example usage (in your `main.tf`):
```
provider "k3d" {
  fixes = {
      "dns" = false
  }
}
```